### PR TITLE
Add config option to filter cards by shelf exam

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -21,7 +21,9 @@ class SignalThread(QThread):
 
 def do_the_thing(qid):
     config = mw.addonManager.getConfig(__name__)
-    openBrowseLink(f"tag:#AK_Step{config['step']}_v{config['AnKing_version']}::#UWorld*::{qid}")
+    str = f"tag:#AK_Step{config['step']}_v{config['AnKing_version']}::#UWorld::*{qid} & tag:#AK*{config['shelf']}"
+    print(str)
+    openBrowseLink(str)
 
 signal_thread = SignalThread()
 signal_thread.qid_set_signal.connect(do_the_thing)

--- a/__init__.py
+++ b/__init__.py
@@ -22,7 +22,6 @@ class SignalThread(QThread):
 def do_the_thing(qid):
     config = mw.addonManager.getConfig(__name__)
     str = f"tag:#AK_Step{config['step']}_v{config['AnKing_version']}::#UWorld::*{qid} & tag:#AK*{config['shelf']}"
-    print(str)
     openBrowseLink(str)
 
 signal_thread = SignalThread()

--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
     "step": 2,
-    "AnKing_version": "*"
+    "AnKing_version": "*",
+    "shelf": "Peds"
 }

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
     "step": 2,
     "AnKing_version": "*",
-    "shelf": "Peds"
+    "shelf": "*"
 }

--- a/config.md
+++ b/config.md
@@ -6,3 +6,7 @@ can be set to a number, like 11, to open tags like `#AK_Step2_v`, or an asterisk
 with all versions.
 If you wanted to add your own tags, you could even set it to `JohhnysCustomTags`, and then it would open
 tags that looked like `#AK_Step2_vJohnnysCustomTags::#UWorld::12345`, although it would be a little ugly
+
+### Shelf
+can be set to a particular shelf topic to filter to, or an asterisk in quotes ("*") to work 
+with all topics.


### PR DESCRIPTION
While using the addon, I noticed that the Anking tagged cards are not always part of the same "Shelf" tag. This allows users to select a Shelf that they want to filter for and created a query that selects cards based on both the UWorld question ID as well as the relevant Shelf Exam topic that they are studying for.